### PR TITLE
Fix Document not proper #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Key                               | Type   | Description               | Default
 In your `metadata.rb` you need to add `depends chef_slack'` and add `include_recipe 'chef_slack'` to your recipe. Passing the below will use default attributes
 
 ```ruby
-slack_notify "Say Summat!"
+chef_slack_notify "Say Summat!"
 ```
 
 ```ruby
-slack_notify "send_notification_message" do
+chef_slack_notify "send_notification_message" do
   message "This is a notification message"
   webhook_url 'https://hooks.slack.com/services/XXXX/XXXXXXX/XXXXXX'
   not_if { node['im_boring'] }
@@ -35,7 +35,7 @@ end
 ```
 
 ```ruby
-slack_notify "channel_nothing" do
+chef_slack_notify "channel_nothing" do
   message "heres a message to kick off later"
   username 'test_user'
   channels ['foo','bar']
@@ -44,7 +44,7 @@ slack_notify "channel_nothing" do
 end
 
 something "talk_as_test_user_to_multiple_channels" do
-  notifies :say, "slack[channel_nothing]", :immediately
+  notifies :notify, "slack[channel_nothing]", :immediately
 end
 ```
 


### PR DESCRIPTION
### Description

Document not follow resource `Custom Resource Usage` and also `notifies`. 

Please use following: 

`chef_slack_notify "Say Summat!"`

```
chef_slack_notify "send_notification_message" do
  message "This is a notification message"
  webhook_url 'https://hooks.slack.com/services/XXXX/XXXXXXX/XXXXXX'
  not_if { node['im_boring'] }
end
```

```
chef_slack_notify "channel_nothing" do
  message "heres a message to kick off later"
  username 'test_user'
  channels ['foo','bar']
  webhook_url 'https://hooks.slack.com/services/XXXX/XXXXXXX/XXXXXX'
  action :nothing
end

something "talk_as_test_user_to_multiple_channels" do
  notifies :notify, "chef_slack_notify[channel_nothing]", :immediately
end
```
#### This is because your cookbook name is `chef_slack` and you only have one action ie, `notify`
### Issues Resolved
1. Update/correct document 
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
