### PR TITLE
Add icon_emoji option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ slack_notify "channel_nothing" do
   username 'test_user'
   channels ['foo','bar']
   webhook_url 'https://hooks.slack.com/services/XXXX/XXXXXXX/XXXXXX'
+  icon_emoji ':tada:'
   action :nothing
 end
 

--- a/resources/notify.rb
+++ b/resources/notify.rb
@@ -4,6 +4,7 @@ property :message, String, name_attribute: true
 property :channels, Array, default: []
 property :username, String
 property :webhook_url, String
+property :icon_emoji, String
 
 action :notify do
   # install the gem if missing
@@ -24,14 +25,18 @@ action :notify do
           end
 
   if new_resource.channels.empty?
+    options = {}
+    options['username'] = new_resource.username if new_resource.username
+    options['icon_emoji'] = new_resource.icon_emoji if new_resource.icon_emoji
     converge_by "notify Slack with message: #{message}" do
-      slack.ping(new_resource.message)
+      slack.ping(new_resource.message, options)
     end
   else
     new_resource.channels.each do |channel|
       options = {}
       options['channel'] = channel if new_resource.channels
       options['username'] = new_resource.username if new_resource.username
+      options['icon_emoji'] = new_resource.icon_emoji if new_resource.icon_emoji
       converge_by "notify Slack channel #{channel} with message: #{message}" do
         slack.ping(new_resource.message, options)
       end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,4 +1,5 @@
 slack_notify 'send_notification_message' do
   message "chef_slack test from #{node['platform']} #{node['platform_version']}"
   webhook_url 'https://hooks.slack.com/services/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'
+  icon_emoji ':tada:'
 end


### PR DESCRIPTION
Signed-off-by: Eric Heydrick <eheydrick@gmail.com>

### Description

Add `icon_emoji` property to the custom resource. Also allow using `username` and `icon_emoji` when `channel` isn't specified. 

Tested locally in test-kitchen.

### Issues Resolved

None

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
