### PR TITLE
[deprecation fix] Rename message to new_resource.message

### DIFF
--- a/resources/notify.rb
+++ b/resources/notify.rb
@@ -28,7 +28,7 @@ action :notify do
     options = {}
     options['username'] = new_resource.username if new_resource.username
     options['icon_emoji'] = new_resource.icon_emoji if new_resource.icon_emoji
-    converge_by "notify Slack with message: #{message}" do
+    converge_by "notify Slack with message: #{new_resource.message}" do
       slack.ping(new_resource.message, options)
     end
   else


### PR DESCRIPTION
Deprecated features used!
         rename message to new_resource.message at 1 location:
           - /tmp/kitchen/cache/cookbooks/chef_slack/resources/notify.rb:31:in `block in class_from_file'
          See https://docs.chef.io/deprecations_namespace_collisions.html for further details.

### Description

Remove deprecation
