### PR TITLE
Fix Deprecated features used! Warning  Obvious fix.

### DIFF
--- a/resources/notify.rb
+++ b/resources/notify.rb
@@ -37,7 +37,7 @@ action :notify do
       options['channel'] = channel if new_resource.channels
       options['username'] = new_resource.username if new_resource.username
       options['icon_emoji'] = new_resource.icon_emoji if new_resource.icon_emoji
-      converge_by "notify Slack channel #{channel} with message: #{message}" do
+      converge_by "notify Slack channel #{channel} with message: #{new_resource.message}" do
         slack.ping(new_resource.message, options)
       end
     end


### PR DESCRIPTION
Obvious fix 

### Description

       Deprecated features used!
         rename message to new_resource.message at 1 location:
           - C:/kitchen/cache/cookbooks/chef_slack/resources/notify.rb:40:in `block (2 levels) in class_from_file'
          See https://docs.chef.io/deprecations_namespace_collisions.html for further details.

### Issues Resolved

fixes the above warning

### Check List

- [- ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ x] New functionality includes testing.
- [ x] New functionality has been documented in the README if applicable
- [ x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
